### PR TITLE
Fix version name issue in generated release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@ Change Log
 ==========
 All notable changes to this project will be documented in this file.
 
-[Version 1.0.0 _(2018-04-11)_](https://github.com/xmartlabs/android-snapshot-publisher/releases/tag/v1.0.0)
+[Version 1.0.1 _(Pending release)_]()
+---
+
+### Fixes
+- Fix version name issue in generated release notes. (24)
+
+[Version 1.0.0 _(2018-04-12)_](https://github.com/xmartlabs/android-snapshot-publisher/releases/tag/v1.0.0)
 ---
 
 ### New Features
@@ -12,7 +18,7 @@ It enables you to create snapshot builds and test them locally without the neces
 - Include git branch name in the app custom version name options (#18)
 
 ### Fixes
-- Truncate Fabric Beta's release notes if its length is greater than `16384` characters.
+- Truncate Fabric Beta's release notes if its length is greater than `16384` characters. (#21)
 
 ### Breaking changes
 - `distributionEmails` and `distributionGroupAliases` in Fabric's Beta configuration block are changed to strings instead of a list of strings.

--- a/src/main/kotlin/com/xmartlabs/snapshotpublisher/SnapshotPublisherPlugin.kt
+++ b/src/main/kotlin/com/xmartlabs/snapshotpublisher/SnapshotPublisherPlugin.kt
@@ -47,8 +47,8 @@ class SnapshotPublisherPlugin : Plugin<Project> {
   private fun Project.createTasksForVariant(variant: ApplicationVariant) {
     val assembleTask = AndroidPluginHelper.getAssembleTask(this, variant)
     val bundleTask = AndroidPluginHelper.getBundleTask(this, variant)
-    val generateReleaseNotesTask = createGenerateReleaseNotesTask(variant)
     val updateVersionNameTask = createAndroidVersionTask(variant, assembleTask, bundleTask)
+    val generateReleaseNotesTask = createGenerateReleaseNotesTask(variant, updateVersionNameTask)
     val preparationTasks = listOf(generateReleaseNotesTask, updateVersionNameTask)
 
     createPrepareApkSnapshotTask(variant, assembleTask, preparationTasks)
@@ -59,13 +59,16 @@ class SnapshotPublisherPlugin : Plugin<Project> {
     createGooglePlayDeployTask(variant, preparationTasks)
   }
 
-  private fun Project.createGenerateReleaseNotesTask(variant: ApplicationVariant? = null) =
-      createTask<GenerateReleaseNotesTask>(
-          name = Constants.GENERATE_SNAPSHOT_RELEASE_NOTES_TASK_NAME + (variant?.capitalizedName ?: ""),
-          description = "Generates release notes"
-      ) {
-        this.variant = variant
-      }
+  private fun Project.createGenerateReleaseNotesTask(
+      variant: ApplicationVariant? = null,
+      updateVersionNameTask: UpdateAndroidVersionNameTask? = null
+  ) = createTask<GenerateReleaseNotesTask>(
+      name = Constants.GENERATE_SNAPSHOT_RELEASE_NOTES_TASK_NAME + (variant?.capitalizedName ?: ""),
+      description = "Generates release notes"
+  ) {
+    this.variant = variant
+    updateVersionNameTask?.mustRunAfter(this)
+  }
 
   private fun Project.createAndroidVersionTask(
       variant: ApplicationVariant,

--- a/src/test/groovy/com/xmartlabs/snapshotpublisher/TaskDependenciesTest.groovy
+++ b/src/test/groovy/com/xmartlabs/snapshotpublisher/TaskDependenciesTest.groovy
@@ -21,6 +21,14 @@ class TaskDependenciesTest {
   }
 
   @Test
+  void testGenerateReleaseNotesTaskMustBeRunBeforeUpdateVersionName() {
+    def project = ProjectCreator.mockProject()
+    project.evaluate()
+
+    assertThat(getUpdateVersionNameTask(project), mustRunAfter(Constants.GENERATE_SNAPSHOT_RELEASE_NOTES_TASK_NAME+ ProjectCreator.FLAVOUR_WITH_BUILD_TYPE))
+  }
+
+  @Test
   void testPublishApkTaskDependsOnAssembleTask() {
     def project = ProjectCreator.mockProject()
     project.evaluate()
@@ -87,6 +95,10 @@ class TaskDependenciesTest {
     project.evaluate()
     def bundleTask = project.tasks.getByName("bundle$ProjectCreator.FLAVOUR_WITH_BUILD_TYPE")
     assertThat(bundleTask, mustRunAfter(Constants.UPDATE_ANDROID_VERSION_NAME_TASK_NAME + ProjectCreator.FLAVOUR_WITH_BUILD_TYPE))
+  }
+
+  private static Task getUpdateVersionNameTask(Project project) {
+    project.tasks.getByName("$Constants.UPDATE_ANDROID_VERSION_NAME_TASK_NAME$ProjectCreator.FLAVOUR_WITH_BUILD_TYPE")
   }
 
   private static Task getFabricSnapshotTask(Project project) {


### PR DESCRIPTION
The the version name in the generated release note sometimes where wrong.
It was updated twice, for example if the version name should be `1.0.14-752a1f9`, the release note version appeared as `1.0.14-752a1f9-752a1f9`